### PR TITLE
Load messages in ascending order

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -20,6 +20,7 @@ class ChannelsController < ApplicationController
 
   def show
     @channel = Channel.find(params[:id])
+    @messages = @channel.messages.order(created_at: :asc)
     @message = Message.new
   end
 

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -3,7 +3,7 @@
 </h1>
 <div clas="h-full flex">
     <div class="h-96 overflow-scroll" data-controller="scroll" data-scroll-to-bottom-value="true">
-      <% @channel.messages.each do |message| %>
+      <% @messages.each do |message| %>
         <div>
           <%= message.text %>
         </div>


### PR DESCRIPTION
Fix bug where channel messages were loaded on order of primary key, and not time created at.