### PR TITLE
Lazy loading messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-.idea
+/.idea/
 
 /node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "sentry-rails"
 
 gem "jsbundling-rails"
 
+gem "pagy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mswin mswin64 mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    pagy (6.3.0)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -315,6 +316,7 @@ DEPENDENCIES
   hotwire-livereload
   jbuilder
   jsbundling-rails
+  pagy
   pg (~> 1.1)
   pry-rails
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   before_action :authenticate_user!
 
   protect_from_forgery with: :exception

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -24,8 +24,11 @@ class ChannelsController < ApplicationController
   def show
     @channel = Channel.find(params[:id])
     @channels = Channel.all
-    @messages = @channel.messages.order(created_at: :asc)
     @message = Message.new
+    @pagy, @messages = pagy_countless(@channel.messages.order(created_at: :desc), items: 12)
+    @messages = @messages.reverse
+
+    render "messages/scroll_list" if params[:page]
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/javascript/controllers/scroll_into_view_controller.js
+++ b/app/javascript/controllers/scroll_into_view_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-// Connects to data-controller="scroll-into-view"
-export default class extends Controller {
-  connect() {
-    this.element.scrollIntoView({block: "end"})
-  }
-}

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -14,10 +14,14 @@
     <div class="w-full">
         <div class="h-full flex flex-col">
             <%= turbo_stream_from :messages %>
-            <div id="messages" class="h-96 overflow-scroll mb-3" data-controller="scroll" data-scroll-to-bottom-value="true">
-              <%= render @messages %>
+            <div class="h-96 overflow-scroll mb-3 flex flex-col-reverse">
+              <div id="messages">
+                <%= render @messages %>
+              </div>
+              <div id="next_link">
+                <%= render partial: "messages/next_page" %>
+              </div>
             </div>
-
             <%= render "messages/form", message: @message, channel: @channel %>
         </div>
     </div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: message, id: "message_form" do |f| %>
   <%= f.hidden_field :channel_id, value: channel.id %>
   <div class="w-full flex w-full gap-2">
-    <%= f.text_field :text, class: "input w-full", placeholder: t('message.placeholder', channel_name: @channel.name)  %>
+    <%= f.text_field :text, class: "input w-full", placeholder: t('message.placeholder', channel_name: @channel.name), autocomplete: "off"  %>
     <%= f.button t('message.send'), type: "submit", class: "btn btn-secondary" %>
   </div>
 <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,5 @@
 <div
   id="<%= dom_id(message) %>"
-  data-controller="scroll-into-view"
   class="flex flex-col py-2 border-t border-t-copy"
 >
   <div>

--- a/app/views/messages/_next_page.html.erb
+++ b/app/views/messages/_next_page.html.erb
@@ -1,0 +1,12 @@
+<% if @pagy.next %>
+  <%= turbo_frame_tag(
+      "message-page-#{@pagy.next}",
+      src: pagy_url_for(@pagy, @pagy.next),
+      loading: "lazy",
+      target: "_top",
+  ) do %>
+    <span class="text-center">
+      <%= t('message.loading_messages') %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/messages/scroll_list.html.erb
+++ b/app/views/messages/scroll_list.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag "message-page-#{@pagy.page}" do %>
+  <%= render partial: "messages/next_page" if @pagy.next.present? %>
+  <%= render @messages %>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -74,7 +74,7 @@
 
 # Countless extra: Paginate without any count, saving one query per rendering
 # See https://ddnexus.github.io/pagy/docs/extras/countless
-# require 'pagy/extras/countless'
+require 'pagy/extras/countless'
 # Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (6.3.0)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+# Pagy::DEFAULT[:items]  = 20                                 # default
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#other-variables
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+# Pagy::DEFAULT[:request_path] = "/foo"                        # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the frontend helpers internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/frontend_helpers'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/docs/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/docs/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/docs/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/docs/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/docs/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/docs/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,4 @@ en:
     send_a_message: "Send a message"
     send: "Send"
     placeholder: "Message %{channel_name}"
+    loading_messages: "Loading..."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,6 @@ Channel.destroy_all
 end
 
 channel_names = %w[general specific announcements news random]
-
 channel_names.each do |channel_name|
   channel = Channel.new(
     name: channel_name
@@ -26,10 +25,12 @@ end
 
 Channel.all.each do |channel|
   100.times do
+    date = rand((4.months.ago)..(0.days.ago))
     message = Message.new(
       text: Faker::Lorem.sentence(word_count: 3),
       channel: channel,
-      user: User.all.sample
+      user: User.all.sample,
+      created_at: date,
     )
     puts "Message created!" if message.save!
   end


### PR DESCRIPTION
Used turbo-frames and `pagy` gem to load batches of messages in channel view as user scrolls to the top.

Initially the list of messages is rendered under a lazy loading `<turbo-frame>`, where the `src` path endpoint returns a partial with the next batch of messages, and yet another lazy loading `<turbo-frame>`, creating a recursive effect.

Removed `scroll_into_view_controller` and changes the `flex-direction` of the scroll box to `collumn-reverse`, as it achieves the wanted behavior.