### PR TITLE
Feature/notifications

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -7,6 +7,7 @@ class ChannelsController < ApplicationController
     @channels = Channel.all
     @channel = Channel.new(channel_params)
     if @channel.save
+      handle_notifications
       redirect_to @channel
     else
       flash[:alert] = t('flash.record_not_created', record: t('channel.object'))
@@ -27,6 +28,11 @@ class ChannelsController < ApplicationController
     @messages = @messages.reverse
 
     render "messages/scroll_list" if params[:page]
+  end
+
+  def handle_notifications
+    all_users_except_current = User.where.not(id: current_user.id)
+    all_users_except_current.each { |user| user.unread_notifications.append(message: self) }
   end
 
   private

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -7,7 +7,6 @@ class ChannelsController < ApplicationController
     @channels = Channel.all
     @channel = Channel.new(channel_params)
     if @channel.save
-      handle_notifications
       redirect_to @channel
     else
       flash[:alert] = t('flash.record_not_created', record: t('channel.object'))
@@ -27,12 +26,13 @@ class ChannelsController < ApplicationController
     @pagy, @messages = pagy_countless(@channel.messages.order(created_at: :desc), items: 12)
     @messages = @messages.reverse
 
+    clear_notifications
+
     render "messages/scroll_list" if params[:page]
   end
 
-  def handle_notifications
-    all_users_except_current = User.where.not(id: current_user.id)
-    all_users_except_current.each { |user| user.unread_notifications.append(message: self) }
+  def clear_notifications
+    @channel.unread_notifications.where(user: current_user).destroy_all
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,8 @@ class MessagesController < ApplicationController
     @channel = @message.channel
     respond_to do |format|
       if @message.save
+        set_notifications
+
         @message = Message.new
         format.turbo_stream {
           render turbo_stream: turbo_stream.replace(
@@ -14,6 +16,11 @@ class MessagesController < ApplicationController
         }
       end
     end
+  end
+
+  def set_notifications
+    all_users_except_current = User.where.not(id: current_user.id)
+    all_users_except_current.each { |user| UnreadNotification.create(user: user, message: @message) }
   end
 
   private

--- a/app/helpers/channel_helper.rb
+++ b/app/helpers/channel_helper.rb
@@ -1,0 +1,5 @@
+module ChannelHelper
+  def notifications_count(user, channel)
+    channel.unread_notifications.where(user: user).count
+  end
+end

--- a/app/helpers/channel_helper.rb
+++ b/app/helpers/channel_helper.rb
@@ -1,5 +1,6 @@
 module ChannelHelper
   def notifications_count(user, channel)
-    channel.unread_notifications.where(user: user).count
+    count = channel.unread_notifications.where(user: user).count
+    count if count > 0
   end
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,5 +1,6 @@
 class Channel < ApplicationRecord
   has_many :messages
+  has_many :unread_notifications, through: :messages
 
   validates :name, uniqueness: true, presence: true, allow_blank: false
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :channel
+  has_many :unread_notifications
 
   validates :text, presence: true, allow_blank: false
 

--- a/app/models/unread_notification.rb
+++ b/app/models/unread_notification.rb
@@ -1,0 +1,5 @@
+class UnreadNotification < ApplicationRecord
+  belongs_to :user
+  belongs_to :message
+  delegate :channel, :to => :message
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :messages
+  has_many :unread_notifications
 
   validates :nickname, presence: true, allow_blank: false
 end

--- a/app/views/channels/_list.html.erb
+++ b/app/views/channels/_list.html.erb
@@ -6,9 +6,12 @@
         <span>
             <%= channel.name %>
         </span>
-        <span class="ml-auto">
-            <%= notifications_count(current_user, channel) %>
-        </span>
+        <% count = notifications_count(current_user, channel) %>
+        <% if count %>
+          <span class="badge p-2 ml-auto text-secondary-content bg-secondary">
+              <%= count %>
+          </span>
+        <% end %>
       </span>
     <% end %>
   <% end %>

--- a/app/views/channels/_list.html.erb
+++ b/app/views/channels/_list.html.erb
@@ -1,7 +1,16 @@
 <div id="list" class="w-full flex flex-col gap-1 h-fit text-primary select-none">
   <% channels.each do |channel| %>
     <!-- TODO: Use helper here -->
-    <%= link_to channel.name, channel, id: dom_id(channel), class: "px-3 py-1 rounded-md #{(channel.id == current_channel.id) ? "bg-primary text-primary-content" : "hover:bg-background"}" %>
+    <%= link_to channel, id: dom_id(channel), class: "px-3 py-1 rounded-md w-full #{(channel.id == current_channel.id) ? "bg-primary text-primary-content" : "hover:bg-background"}" do %>
+      <span class="flex gap-16 whitespace-nowrap">
+        <span>
+            <%= channel.name %>
+        </span>
+        <span class="ml-auto">
+            <%= notifications_count(current_user, channel) %>
+        </span>
+      </span>
+    <% end %>
   <% end %>
   <%= render partial: "channels/new_modal" %>
 </div>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -1,6 +1,6 @@
 
 <div class="flex w-full gap-8">
-    <div>
+    <div class="w-max">
         <%= render partial: "list", locals: { channels: @channels, current_channel: @channel } %>
     </div>
     <div class="w-full">

--- a/db/migrate/20240111192224_create_unread_notifications.rb
+++ b/db/migrate/20240111192224_create_unread_notifications.rb
@@ -1,0 +1,10 @@
+class CreateUnreadNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :unread_notifications do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+      t.belongs_to :message, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_08_165037) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_11_192224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_165037) do
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
+  create_table "unread_notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "message_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_unread_notifications_on_message_id"
+    t.index ["user_id"], name: "index_unread_notifications_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -45,4 +54,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_165037) do
 
   add_foreign_key "messages", "channels"
   add_foreign_key "messages", "users"
+  add_foreign_key "unread_notifications", "messages"
+  add_foreign_key "unread_notifications", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@
 Message.destroy_all
 User.destroy_all
 Channel.destroy_all
+UnreadNotification.destroy_all
 
 30.times do
   nickname = Faker::Internet.username
@@ -26,12 +27,18 @@ end
 Channel.all.each do |channel|
   100.times do
     date = rand((4.months.ago)..(0.days.ago))
+    user = User.all.sample
     message = Message.new(
       text: Faker::Lorem.sentence(word_count: 3),
       channel: channel,
-      user: User.all.sample,
+      user: user,
       created_at: date,
     )
     puts "Message created!" if message.save!
+
+    User.where.not(id: user.id).each do |user|
+      notification = UnreadNotification.new(user: user, message: message)
+      puts "Notification created!" if notification.save!
+    end
   end
 end

--- a/spec/factories/unread_notifications.rb
+++ b/spec/factories/unread_notifications.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :unread_notification do
+    user
+    message
+  end
+end

--- a/spec/helpers/channel_helper_spec.rb
+++ b/spec/helpers/channel_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+RSpec.describe ChannelHelper, type: :helper do
+  let(:user) { create(:user) }
+  let(:channel) { create(:channel) }
+  let(:message1) { create(:message, channel: channel) }
+  let(:message2) { create(:message, channel: channel) }
+  describe "notifications_count" do
+    it 'should be 2' do
+      create(:unread_notification, message: message1, user: user)
+      create(:unread_notification, message: message2, user: user)
+      expect(notifications_count(user, channel)).to eq(2)
+
+      create(:unread_notification, message: message2, user: user)
+      expect(notifications_count(user, channel)).to eq(3)
+    end
+  end
+end

--- a/spec/models/unread_notification_spec.rb
+++ b/spec/models/unread_notification_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe UnreadNotification, type: :model do
+  let(:unread_notification) { create(:unread_notification) }
+  it "should have user" do
+    expect(unread_notification.user).to be_a(User)
+  end
+
+  it "should have message" do
+    expect(unread_notification.message).to be_a(Message)
+  end
+
+  it "should have channel" do
+    expect(unread_notification.channel).to be_a(Channel)
+  end
+end

--- a/spec/requests/channels_spec.rb
+++ b/spec/requests/channels_spec.rb
@@ -38,4 +38,14 @@ RSpec.describe "Channels", type: :request do
       end
     end
   end
+
+  describe "GET /channels/:id" do
+    let(:message) { create(:message) }
+    it 'should clear notification' do
+      create(:unread_notification, message: message, user: user)
+      expect {
+        get channel_path(message.channel)
+      }.to change(UnreadNotification, :count)
+    end
+  end
 end

--- a/spec/requests/message_spec.rb
+++ b/spec/requests/message_spec.rb
@@ -8,11 +8,21 @@ RSpec.describe "Messages", type: :request do
   describe "POST /create" do
     let(:channel) { create(:channel) }
     let(:invalid_attributes) { { message: { channel_id: channel.id, text: "" } } }
+    let(:valid_attributes) { { message: { channel_id: channel.id, text: "Valid text" } } }
 
     it 'should not create invalid message' do
       expect {
         post '/messages', params: invalid_attributes
       }.to change(Message, :count).by(0)
+    end
+
+    it 'should set notifications' do
+      create(:user)
+      create(:user)
+
+      expect {
+        post '/messages', params: valid_attributes
+      }.to change(UnreadNotification, :count).by(2)
     end
   end
 end


### PR DESCRIPTION
Added notifications for unread messages.

Added the model `UnreadNotification`.
Every time a message gets created by a `User`, 1 *UnreadNotification* gets created for each other `User`.
When a users visits `channels/:id`, all the `User`'s notifications connected to that `Channel` gets destroyed.

Number of unread `Messages` gets displayed next to the `Channel`'s name.

![image](https://github.com/hoglund003/chat/assets/29040689/d62453f7-f0c6-4c71-90b6-ddf9ff7558d7)
